### PR TITLE
Fix/easy writer

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bothub-chat/ui",
-  "version": "2.8.6-stage-d16740e7-2ad0-4cb3-b2e2-56a9d4b06dd8",
+  "version": "2.8.6-fix-easy-writer-383ee8ba-0be2-4ccf-a429-71c4a0539ee4",
   "description": "Bothub UI Components",
   "keywords": [
     "bothub",

--- a/packages/ui/src/components/range-field/index.tsx
+++ b/packages/ui/src/components/range-field/index.tsx
@@ -73,12 +73,12 @@ export const RangeField: React.FC<RangeFieldProps> = ({
           {label}
         </RangeFieldLabel>
       )}
+      {(typeof label !== 'string' && !skeleton) && label}
       {preview && (
         <RangeFieldFormattedValue>
           {preview(value)}
         </RangeFieldFormattedValue>
       )}
-      {(typeof label !== 'string' && !skeleton) && label}
       {!skeleton && (
         <Tooltip 
           label={String(value)}


### PR DESCRIPTION
переместил label повыше

nextjs-client MR: [https://lab18.matbea.xyz/gpt/nextjs-client/-/merge_requests/166](https://lab18.matbea.xyz/gpt/nextjs-client/-/merge_requests/166)